### PR TITLE
Release improved logging, improved comparison

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,6 @@
 flake8==3.7.9
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.2#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.2a#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.3.2#egg=gobconfig
 pytest==3.6.3
 pytest-cov==2.5.1
 requests==2.20.0
-xlrd==1.2.0

--- a/src/tests/data_consistency/test_data_consistency_test.py
+++ b/src/tests/data_consistency/test_data_consistency_test.py
@@ -329,6 +329,7 @@ class TestDataConsistencyTest(TestCase):
         self.assertTrue(inst.equal_values([0,2.5], "[0, 2.5]"))
         self.assertFalse(inst.equal_values("aap noot mies", "aap noot"))
         self.assertFalse(inst.equal_values("aap noot", "aap noot mies"))
+        self.assertTrue(inst.equal_values("  Aap \t nOOt \n", "aap noot"))
 
     def test_transform_gob_row(self):
         inst = DataConsistencyTest('cat', 'col')
@@ -393,7 +394,7 @@ class TestDataConsistencyTest(TestCase):
         self.assertIsNone(inst.gob_key_errors.get('a'))
         inst._log_result(0, 0, 0, 0, 0)
         mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
+        mock_logger.warning.assert_called_with('something wrong with a')
 
         mock_logger.error.reset_mock()
         mock_logger.warning.reset_mock()


### PR DESCRIPTION
Show counts of source and GOB collection
Show source value issues as warnings instead of info

Compare source and GOB value case-insensitive, do not report whitespace differences

Remove xldr lib as it is now part of GOB-Core (where it should be)