### PR TITLE
Fix JSON warning, dockerfile and update GOB-Core

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,7 @@
 FROM amsterdam/python:3.7-buster
 MAINTAINER datapunt@amsterdam.nl
 
-RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get update && apt-get install -y git
 
 # Install gobtest in /app folder
 WORKDIR /app

--- a/src/gobtest/data_consistency/data_consistency_test.py
+++ b/src/gobtest/data_consistency/data_consistency_test.py
@@ -287,7 +287,7 @@ class DataConsistencyTest:
                 result[dst_key] = source_row.get(source_key, self.SKIP_VALUE)
         else:
             # Skip JSON's that are not imported per attribute
-            self._src_key_warning(attr_name, f"Skip JSON {attr_name} that is imported as non-JSON")
+            self._src_key_warning(attr_name, f"Skip JSON {attr_name} that is imported as non- or empty-JSON")
 
     def _transform_gob_row(self, gob_row: dict):
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 flake8==3.7.9
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.2a#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.3#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.3.2#egg=gobconfig
 pytest==3.6.3
 pytest-cov==2.5.1


### PR DESCRIPTION
The JSON warning can also refer to JSON's that have no field specs in the import def
Fix Dockerfile to follow recommendations
Update GOB-Core to use xldr lib