### PR TITLE
PGB-1265 Bevindingen

### DIFF
--- a/src/gobtest/data_consistency/data_consistency_test.py
+++ b/src/gobtest/data_consistency/data_consistency_test.py
@@ -362,13 +362,15 @@ WHERE
             src_value = re.sub(r"\s+", "", str(src_value)).lower()
             return gob_value == src_value
 
-    def _validate_row(self, source_row: dict, gob_row: dict) -> bool:
-        expected_values = self._transform_source_row(source_row)
+    def _register_compared_columns(self, columns):
         if not self.compared_columns:
             # Register the columns that have been compared
-            self.compared_columns = expected_values.keys()
-        gob_row = self._transform_gob_row(gob_row)
+            self.compared_columns = columns
 
+    def _validate_row(self, source_row: dict, gob_row: dict) -> bool:
+        expected_values = self._transform_source_row(source_row)
+        self._register_compared_columns(expected_values.keys())
+        gob_row = self._transform_gob_row(gob_row)
         start_error_cnt = len(logger.get_errors())
 
         mismatches = []

--- a/src/gobtest/data_consistency/handler.py
+++ b/src/gobtest/data_consistency/handler.py
@@ -16,7 +16,7 @@ def data_consistency_test_handler(msg):
     application = msg['header'].get('application')
     msg['header']['entity'] = msg['header'].get('entity', collection)
 
-    logger.configure(msg, 'Data consistency E2E test')
+    logger.configure(msg, 'Data consistency test')
 
     assert all([catalog, collection]), "Expecting header attributes 'catalogue' and 'collection'"
     id = f"{catalog} {collection} {application or ''}"

--- a/src/tests/data_consistency/test_handler.py
+++ b/src/tests/data_consistency/test_handler.py
@@ -20,7 +20,7 @@ class TestDataConsistencyTestHandler(TestCase):
         res = data_consistency_test_handler(msg)
 
         # Assert logger configured
-        mock_logger.configure.assert_called_with(msg, 'Data consistency E2E test')
+        mock_logger.configure.assert_called_with(msg, 'Data consistency test')
 
         mock_test.assert_called_with('the catalogue', 'the collection', 'the application')
         mock_test.return_value.run.assert_called_once()


### PR DESCRIPTION
Volgende bevindingen zijn verholpen:

Verschillende benamingen worden nu gebruikt voor 'data consistency e2e test' / 'data_consistency_test'. Naamgeving uniformeren naar “data consistency test”, zodat dit ook uniform in Iris wordt getoond

Nu wordt met een warning aangegeven welk attribuut niet gechecked kan worden. Impliciet betekent dit dat de andere attributen wel gechecked kunnen worden. Of dat alle attributen zijn van de objectklasse is niet expliciet te achterhalen. Graag een info-melding van ieder attribuut dat checked wordt.