### PR TITLE
PGB-1352 Spin up thread per service

### DIFF
--- a/src/gobtest/__main__.py
+++ b/src/gobtest/__main__.py
@@ -43,7 +43,7 @@ SERVICEDEFINITION = {
 
 def init():
     if __name__ == "__main__":
-        messagedriven_service(SERVICEDEFINITION, "Test")
+        messagedriven_service(SERVICEDEFINITION, "Test", {"thread_per_service": True})
 
 
 init()

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -11,4 +11,4 @@ class TestMain(TestCase):
         from gobtest import __main__ as module
         with patch.object(module, "__name__", "__main__"):
             module.init()
-            mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "Test")
+            mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "Test", {"thread_per_service": True})


### PR DESCRIPTION
thread_per_service is the same as used in GOB-Upload -> queues can be handled in parallel

This would have prevented the failing E2E tests Sunday and Monday. They were both waiting for the very-long-running data consistency tests. Once they were gone both E2E tests ran at the same time, bullying each other. In the end, neither of them were happy.