### PR TITLE
Fix Data Consistency Test for QA catalog

### DIFF
--- a/src/gobtest/__main__.py
+++ b/src/gobtest/__main__.py
@@ -13,7 +13,7 @@ from gobcore.message_broker.notifications import get_notification, listen_to_not
 from gobcore.workflow.start_workflow import start_workflow
 
 from gobtest.e2e.handler import end_to_end_test_handler, end_to_end_check_handler
-from gobtest.data_consistency.handler import data_consistency_test_handler
+from gobtest.data_consistency.handler import data_consistency_test_handler, can_handle
 
 
 def on_dump_listener(msg):
@@ -28,7 +28,8 @@ def on_dump_listener(msg):
         'collection': notification.header.get('collection'),
     }
 
-    start_workflow(workflow, arguments)
+    if can_handle(**arguments):
+        start_workflow(workflow, arguments)
 
 
 SERVICEDEFINITION = {

--- a/src/tests/data_consistency/test_handler.py
+++ b/src/tests/data_consistency/test_handler.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
-from gobtest.data_consistency.handler import data_consistency_test_handler
+from gobtest.data_consistency.handler import data_consistency_test_handler, can_handle, GOBConfigException
 
 
 class TestDataConsistencyTestHandler(TestCase):
@@ -38,3 +38,19 @@ class TestDataConsistencyTestHandler(TestCase):
                 'errors': mock_logger.get_errors.return_value,
             }
         }, res)
+
+        mock_logger.error.reset_mock()
+        mock_test.side_effect = GOBConfigException
+        res = data_consistency_test_handler(msg)
+        mock_logger.error.assert_called()
+        # Assert that a response is returned
+        self.assertEqual(res, {'header': ANY, 'summary': ANY})
+
+    @patch("gobtest.data_consistency.handler.DataConsistencyTest")
+    def test_can_handle(self, mock_data_consistency_test):
+        result = can_handle("cat", "col", "app")
+        self.assertEqual(result, True)
+
+        mock_data_consistency_test.side_effect = GOBConfigException
+        result = can_handle("cat", "col", "app")
+        self.assertIsNone(result)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -14,7 +14,8 @@ class TestMain(TestCase):
             mock_messagedriven_service.assert_called_with(SERVICEDEFINITION, "Test", {"thread_per_service": True})
 
     @patch("gobtest.__main__.start_workflow")
-    def test_on_dump_listener(self, mock_start_workflow):
+    @patch("gobtest.__main__.can_handle")
+    def test_on_dump_listener(self, mock_can_handle, mock_start_workflow):
         msg = {
             'type': 'dump',
             'contents': {'collection': 'SOME COLL', 'catalog': 'SOME CAT'},
@@ -24,6 +25,12 @@ class TestMain(TestCase):
             }
         }
 
+        mock_can_handle.return_value = False
+        on_dump_listener(msg)
+
+        mock_start_workflow.assert_not_called()
+
+        mock_can_handle.return_value = True
         on_dump_listener(msg)
 
         mock_start_workflow.assert_called_with({'workflow_name': DATA_CONSISTENCY_TEST}, {


### PR DESCRIPTION
The QA catalog does not have an import definition.
It is the result of a workflow step and not of an import of a dataset