### PR TITLE
Update gob config en core version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 flake8==3.7.9
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.7i#egg=gobcore
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11a#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.7l#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11b#egg=gobconfig
 pytest==3.6.3
 pytest-cov==2.5.1
 requests==2.20.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 flake8==3.7.9
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.7h#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.7i#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11a#egg=gobconfig
 pytest==3.6.3
 pytest-cov==2.5.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 flake8==3.7.9
 -e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.7h#egg=gobcore
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.10a#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11a#egg=gobconfig
 pytest==3.6.3
 pytest-cov==2.5.1
 requests==2.20.0


### PR DESCRIPTION
Update config and core version. GOB-Test now has the latest version of the GOB model.