### PR TITLE
Wait for process to be finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ source venv/bin/activate
 
 # Run
 
+Set environment:
+
+```bash
+export $(cat .env | xargs)  # Copy from .env.example if missing
+```
+
+
 Start the service:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       MESSAGE_BROKER_ADDRESS: rabbitmq
       API_HOST: http://gobapi:8001
+      MANAGEMENT_API_HOST: http://gobmanagement:8001
       ANALYSE_DATABASE_USER: gob
       ANALYSE_DATABASE_PASSWORD: insecure
       ANALYSE_DATABASE_HOST_OVERRIDE: analyse_database

--- a/src/gobtest/e2e/e2etest.py
+++ b/src/gobtest/e2e/e2etest.py
@@ -25,7 +25,7 @@ class E2ETest:
     result.
 
     """
-    MAX_SECONDS_TO_WAIT_FOR_PROCESS_TO_FINISH = 600     # Wait for maximally 10 minutes
+    MAX_SECONDS_TO_WAIT_FOR_PROCESS_TO_FINISH = 120     # Wait for maximally 2 minutes
     CHECK_EVERY_N_SECONDS_FOR_PROCESS_TO_FINISH = 5     # Check every 5 seconds
 
     test_catalog = "test_catalogue"


### PR DESCRIPTION
Prerequisite: notifications and start of workflow run with minimal delay.
- A PR on GOB-Core (https://github.com/Amsterdam/GOB-Core/pull/501) has been submitted to allow notification handlers to run in separate threads
- GOB-Workflow already runs with minimal delay

Given the assumption that notification queues and the start workflow queue are normally empty (which is the case if the GOB-Core PR and GOB-Export (https://github.com/Amsterdam/GOB-Export/pull/625) PR's have been accepted, waiting for a process to have ended is implemented as follows:

- A new endpoint in GOB-Management (https://github.com/Amsterdam/GOB-Management/pull/180) is used to check for jobs that belong to a process.
- The wait-check will use this endpoint to check if the process has started (#jobs > 0)
- If the process has started and all jobs have ended the process is assumed to have finished
- In that case the number of pending messages in the notification and start-workflow queues is checked
- If the number of messages is 0 then this confirms the process to really have been finished
- Then an extra check (with a configurable delay) is performed to re-check the process.
- If this check still confirms the process to have been finished the process is reported to have finished

- if the process does not exist or the checks repeatedly indicate the process to be running a timeout value is used to end the check. This timeout value is configurable and is read from the message that starts the process-wait.
    - In this case a warning message is issued

An alternative approach that has been considered is to examine the messages in the notification and start-workflow queues.
The message bus does not allow peeking messages. But messages can be read and not acknowledged.
The disadvantage is that messages will change order but also that messages might be considered that do not lead to workflows.

Given the fact that message delays in the given queues is minimized the approach to peek messaged has not been implemented.
The implemented approach is easy and maintainable and does not 'touch' messages on the bus.