### PR TITLE
Explicitely call `disconnect` when exiting DataConsistencyTest context

### DIFF
--- a/src/gobtest/data_consistency/data_consistency_test.py
+++ b/src/gobtest/data_consistency/data_consistency_test.py
@@ -112,6 +112,14 @@ class DataConsistencyTest:
         # Ignore columns that have enriched values in GOB-Import
         self.ignore_enriched_columns()
 
+    def __enter__(self):
+        """Enter DataConsistencyTest context."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit DataConsistencyTest context, always disconnect from datastores."""
+        self._disconnect()
+
     def ignore_filtered_columns(self) -> None:
         """Ignore any fields that have a filter definition.
 
@@ -749,6 +757,12 @@ WHERE
 
         self.gob_db = DatastoreFactory.get_datastore(get_datastore_config(GOB_DB))
         self.gob_db.connect()
+
+    def _disconnect(self):
+        if hasattr(self, "src_datastore") and self.src_datastore:
+            self.src_datastore.disconnect()
+        if hasattr(self, "gob_db") and self.gob_db:
+            self.gob_db.disconnect()
 
     def _read_from_gob_db(self, query) -> Optional[Iterator[tuple[Any, Any]]]:
         """Read from the GOB db using server-side cursor. Reconnect if any query fails.

--- a/src/gobtest/data_consistency/handler.py
+++ b/src/gobtest/data_consistency/handler.py
@@ -47,7 +47,8 @@ def data_consistency_test_handler(msg):
     # No return value. Results are captured by logger.
     logger.info(f"Data consistency test {id} started")
     try:
-        DataConsistencyTest(catalog, collection, application).run()
+        with DataConsistencyTest(catalog, collection, application) as tester:
+            tester.run()
     except GOBConfigException as e:
         logger.error(f"Dataset connection failed: {str(e)}")
     except (NotImplementedCatalogError, NotImplementedApplicationError, GOBException) as e:

--- a/src/tests/data_consistency/test_data_consistency_test.py
+++ b/src/tests/data_consistency/test_data_consistency_test.py
@@ -1001,3 +1001,28 @@ WHERE
             call('GOBDatabase_CONFIG'),
             call().connect(),
         ])
+
+    def test_context(self):
+        mock_src_ds = MagicMock()
+        mock_gob_db = MagicMock()
+
+        with DataConsistencyTest('cat', 'col') as test:
+            test.src_datastore = mock_src_ds
+            test.gob_db = mock_gob_db
+
+        mock_src_ds.disconnect.assert_called()
+        mock_gob_db.disconnect.assert_called()
+
+    def test_context_exception(self):
+        mock_src_ds = MagicMock()
+        mock_gob_db = MagicMock()
+
+        with self.assertRaises(Exception):
+            with DataConsistencyTest('cat', 'col') as test:
+                test.src_datastore = mock_src_ds
+                test.gob_db = mock_gob_db
+
+                raise Exception
+
+        mock_src_ds.disconnect.assert_called()
+        mock_gob_db.disconnect.assert_called()

--- a/src/tests/data_consistency/test_handler.py
+++ b/src/tests/data_consistency/test_handler.py
@@ -21,7 +21,8 @@ class TestDataConsistencyTestHandler(TestCase):
         res = data_consistency_test_handler(msg)
 
         mock_test.assert_called_with('the catalogue', 'the collection', 'the application')
-        mock_test.return_value.run.assert_called_once()
+        mock_test.return_value.__enter__.return_value.run.assert_called_once()
+        mock_test.return_value.__exit__.assert_called_once()
 
         self.assertEqual({
             'header': {


### PR DESCRIPTION
Make sure we disconnect on exceptions